### PR TITLE
Added brightness and start pages

### DIFF
--- a/custom_components/button_plus/__init__.py
+++ b/custom_components/button_plus/__init__.py
@@ -15,7 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 
 # List of platforms to support. There should be a matching .py file for each,
 # eg <cover.py> and <sensor.py>
-PLATFORMS: list[str] = ["button", "text"]
+PLATFORMS: list[str] = ["button", "text", "number"]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/button_plus/button_plus_api/event_type.py
+++ b/custom_components/button_plus/button_plus_api/event_type.py
@@ -4,6 +4,7 @@ from enum import Enum
 class EventType(int, Enum):
     CLICK = 0
     LONG_PRESS = 1
+    PAGE_STATUS = 6
     BLUE_LED = 8
     RED_LED = 9
     GREEN_LED = 10
@@ -14,3 +15,6 @@ class EventType(int, Enum):
     VALUE = 15
     UNIT = 17
     SENSOR_VALUE = 18
+    SET_PAGE = 20
+    BRIGHTNESS_LARGE_DISPLAY = 24
+    BRIGHTNESS_MINI_DISPLAY = 25

--- a/custom_components/button_plus/button_plus_api/model.py
+++ b/custom_components/button_plus/button_plus_api/model.py
@@ -54,7 +54,8 @@ class Info:
 
 class Core:
     def __init__(self, name: str, location: str, auto_backup: bool, brightness_large_display: int,
-                 brightness_mini_display: int, led_color_front: int, led_color_wall: int, color: int):
+                 brightness_mini_display: int, led_color_front: int, led_color_wall: int, color: int,
+                 topics: List[Dict[str, Any]]):
         self.name = name
         self.location = location
         self.auto_backup = auto_backup
@@ -63,6 +64,7 @@ class Core:
         self.led_color_front = led_color_front
         self.led_color_wall = led_color_wall
         self.color = color
+        self.topics = topics
 
     @staticmethod
     def from_dict(data: Dict[str, Any]) -> 'Core':
@@ -74,7 +76,8 @@ class Core:
             brightness_mini_display=data['brightnessminidisplay'],
             led_color_front=data['ledcolorfront'],
             led_color_wall=data['ledcolorwall'],
-            color=data['color']
+            color=data['color'],
+            topics=data['topics']
         )
 
 

--- a/custom_components/button_plus/buttonplushub.py
+++ b/custom_components/button_plus/buttonplushub.py
@@ -29,6 +29,7 @@ class ButtonPlusHub:
         self.button_entities = {}
         self.label_entities = {}
         self.top_label_entities = {}
+        self.brightness_entities = {}
 
         device_registry = dr.async_get(hass)
 
@@ -61,3 +62,6 @@ class ButtonPlusHub:
 
     def add_top_label(self, button_id, entity):
         self.top_label_entities[str(button_id)] = entity
+
+    def add_brightness(self, identifier, entity):
+        self.brightness_entities[identifier] = entity

--- a/custom_components/button_plus/number.py
+++ b/custom_components/button_plus/number.py
@@ -1,0 +1,141 @@
+""" Platform for light integration. """
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.components.mqtt import client as mqtt
+from .button_plus_api.event_type import EventType
+from . import ButtonPlusHub
+from packaging import version
+
+from .const import DOMAIN, MANUFACTURER
+
+_LOGGER = logging.getLogger(__name__)
+
+brightness = []
+
+
+async def async_setup_entry(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Add switches for passed config_entry in HA."""
+
+    hub: ButtonPlusHub = hass.data[DOMAIN][config_entry.entry_id]
+
+    if version.parse(hub.config.info.firmware) < version.parse('1.11'):
+        _LOGGER.info(f"Current version {hub.config.info.firmware} doesn't support the brightness, it must be at least firmware version {min_version}")
+        return
+
+    _LOGGER.debug(f"Creating number with parameters: {hub.hub_id}")
+    # _LOGGER.debug(f"Creating Lights with parameters: {button.button_id} {button.label} {hub.hub_id}")
+    mini = ButtonPlusMiniBrightness(hub)
+    brightness.append(mini)
+    hub.add_brightness("mini", mini)
+
+    large = ButtonPlusLargeBrightness(hub)
+    brightness.append(large)
+    hub.add_brightness("large", mini)
+
+    async_add_entities(brightness)
+
+
+
+class ButtonPlusBrightness(NumberEntity):
+    def __init__(self, hub: ButtonPlusHub, brightness_type: str, event_type: EventType):
+        self._hub = hub
+        self._hub_id = hub.hub_id
+        self._brightness_type = brightness_type
+        self._attr_unique_id = f'brightness-{brightness_type}-{self._hub_id}'
+        self.entity_id = f"brightness.{brightness_type}_{self._hub_id}"
+        self._attr_name = f'brightness-{brightness_type}'
+        self.event_type = event_type
+        self._topics = hub.config.core.topics
+        self._attr_icon = "mdi:television-ambient-light"
+
+    @property
+    def native_max_value(self) -> float:
+        return 100
+
+    @property
+    def native_min_value(self) -> float:
+        return 0
+
+    @property
+    def native_unit_of_measurement(self) -> str:
+        return "%"
+
+    def update(self) -> None:
+        """Fetch new state data for this light."""
+        # get latest stats from mqtt for this light
+        # then update self._state
+        _LOGGER.debug(f"Update {self.name} (attr_name: {self._attr_name}) (unique: {self._attr_unique_id})")
+
+    @property
+    def device_info(self)-> DeviceInfo:
+        """Return information to link this entity with the correct device."""
+        via_device = (DOMAIN, self._hub.hub_id)
+
+        match self.event_type:
+            case EventType.BRIGHTNESS_LARGE_DISPLAY:
+                name = f"Display Module"
+                connections: set[tuple[str, str]] = {("display_module", 1)}
+                model = "Display Module"
+                identifiers = {(DOMAIN, f'{self._hub.hub_id}_large_display_module')}
+                device_info = DeviceInfo(name=name, connections=connections, model=model, identifiers=identifiers, manufacturer=MANUFACTURER, via_device=via_device)
+            case EventType.BRIGHTNESS_MINI_DISPLAY:
+                name = f"BAR Module 1"
+                #name = f"Brightness Mini Display Module"
+                connections: set[tuple[str, str]] = {
+                        #(DOMAIN, f'{self._hub.hub_id}_{self._btn_id}_bar_module_{self._connector.connector_id}')
+                        ("bar_module", 1),
+                        ("bar_module", 2),
+                        ("bar_module", 3)
+                    }
+                model = "BAR Module"
+                identifiers = {(DOMAIN, f'{self._hub.hub_id}_display_module_mini_brightness')}
+                device_info = DeviceInfo(name=name, connections=connections, model=model, identifiers=identifiers, manufacturer=MANUFACTURER, via_device=via_device)
+
+        return device_info
+
+
+    async def async_set_value(self, value: float) -> None:
+        """Set the text value and publish to mqtt."""
+        # TODO: Add support for mini
+        label_topic = f"buttonplus/{self._hub_id}/brightness/{self._brightness_type}"
+        _LOGGER.debug(f"ButtonPlus brightness update for {self.entity_id}")
+        _LOGGER.debug(f"ButtonPlus brightness update to {label_topic} with new value: {value}")
+        await mqtt.async_publish(hass=self.hass, topic=label_topic, payload=value, qos=0, retain=True)
+        self._attr_native_value = value
+        self.async_write_ha_state()
+
+
+class ButtonPlusMiniBrightness(ButtonPlusBrightness):
+    """ Numeric entity representation """
+
+    def __init__(self, hub: ButtonPlusHub):
+        super().__init__(hub, "mini", EventType.BRIGHTNESS_MINI_DISPLAY)
+
+    @property
+    def name(self) -> str:
+        """Return the display name of this light."""
+        return f'Brightness mini display'
+
+
+class ButtonPlusLargeBrightness(ButtonPlusBrightness):
+    """ Numeric entity representation """
+
+    def __init__(self, hub: ButtonPlusHub):
+        super().__init__(hub, "large", EventType.BRIGHTNESS_LARGE_DISPLAY)
+
+    @property
+    def name(self) -> str:
+        """Return the display name of this light."""
+        return f'Brightness large display'

--- a/custom_components/button_plus/number.py
+++ b/custom_components/button_plus/number.py
@@ -18,7 +18,6 @@ from .const import DOMAIN, MANUFACTURER
 
 _LOGGER = logging.getLogger(__name__)
 
-brightness = []
 
 
 async def async_setup_entry(
@@ -26,6 +25,9 @@ async def async_setup_entry(
         config_entry: ConfigEntry,
         async_add_entities: AddEntitiesCallback,
 ) -> None:
+
+    brightness = []
+
     """Add switches for passed config_entry in HA."""
 
     hub: ButtonPlusHub = hass.data[DOMAIN][config_entry.entry_id]
@@ -53,12 +55,12 @@ class ButtonPlusBrightness(NumberEntity):
         self._hub = hub
         self._hub_id = hub.hub_id
         self._brightness_type = brightness_type
-        self._attr_unique_id = f'brightness-{brightness_type}-{self._hub_id}'
         self.entity_id = f"brightness.{brightness_type}_{self._hub_id}"
         self._attr_name = f'brightness-{brightness_type}'
         self.event_type = event_type
         self._topics = hub.config.core.topics
         self._attr_icon = "mdi:television-ambient-light"
+        self._attr_unique_id = f'brightness_{brightness_type}-{self._hub_id}'
 
     @property
     def native_max_value(self) -> float:
@@ -85,13 +87,13 @@ class ButtonPlusBrightness(NumberEntity):
 
         match self.event_type:
             case EventType.BRIGHTNESS_LARGE_DISPLAY:
-                name = f"Display Module"
+                name = f"{self._hub_id} Display Module"
                 connections: set[tuple[str, str]] = {("display_module", 1)}
                 model = "Display Module"
                 identifiers = {(DOMAIN, f'{self._hub.hub_id}_large_display_module')}
                 device_info = DeviceInfo(name=name, connections=connections, model=model, identifiers=identifiers, manufacturer=MANUFACTURER, via_device=via_device)
             case EventType.BRIGHTNESS_MINI_DISPLAY:
-                name = f"BAR Module 1"
+                name = f"{self._hub_id} BAR Module 1"
                 #name = f"Brightness Mini Display Module"
                 connections: set[tuple[str, str]] = {
                         #(DOMAIN, f'{self._hub.hub_id}_{self._btn_id}_bar_module_{self._connector.connector_id}')

--- a/custom_components/button_plus/resource/config.json.notes
+++ b/custom_components/button_plus/resource/config.json.notes
@@ -1,5 +1,5 @@
 {
-    "info": { 
+    "info": {
         "largedisplay": 3, // on which connector the large display is hooked up?
         "i2cs": [], // serial communication data probably
         "connectors": [ // Which button+ modules are attached after the screen and the 2 buttons
@@ -16,13 +16,27 @@
     },
     "core": {
         "name": "demo3", // Button+ set name
-        "location": "Living Room", // location where its found 
+        "location": "Living Room", // location where its found
         "color": 15140872, // 24 bit integer representation of the main color
-        "invert": true // wether to invert colors
+        "invert": true, // wether to invert colors
+        "topics": [ //active topics
+            {
+              "brokerid": "ha-button-plus",
+              "topic": "buttonplus/demo3/brightness/large",
+              "payload": "",
+              "eventtype": 24
+            },
+            {
+              "brokerid": "ha-button-plus",
+              "topic": "buttonplus/demo3/brightness/mini",
+              "payload": "",
+              "eventtype": 25
+            }
+          ]
     },
     "mqttbuttons": [ // all possible available button configurations with what mqtt to publish or subscribe
         {
-            "id": 0,   
+            "id": 0,
             "label": "Btn 0",
             "topics": []
         },
@@ -52,14 +66,14 @@
             "topics": []
         },
         {
-            "id": 6, // not following this id scheme yet, the left display button has id 6 for some reason. probably going over each connector and its type 
+            "id": 6, // not following this id scheme yet, the left display button has id 6 for some reason. probably going over each connector and its type
             "label": "Btn 8", // label of this button
             "topics": [ // array of mqtt topics to publish or subscribe
                 {
                     "brokerid": "buttonplus",
                     "topic": "buttonplus/abc",
                     "payload": "dummy",
-                    "eventtype": 0 
+                    "eventtype": 0
                     // different types of event we can have topics for in mqtt:
                     // 0 = 'Click'
                     // 1 = 'Long press'
@@ -125,7 +139,7 @@
             // 5 = 'Center Right'
             // 6 = 'Bottom Left'
             // 7 = 'Bottom Center'
-            // 8 = 'Bottom Right'    
+            // 8 = 'Bottom Right'
             "width": 60, // in % of the display width
             "label": "Central European Time",
             "round": 0, // Round the incoming payload to decimal places, 0 is round to whole numbers


### PR DESCRIPTION
With firmware 1.11 (or 1.10?) it is possible to set the brightness of the display.

- Adds support for brightness
- Added start for page

Workaround:
- Currently for the 'brightness mini display' I use the Bar 1 device, I can't seem to get it working on multiple devices with 1 entity.