### PR TITLE
Fixed multiple devices clashing with add/remove

### DIFF
--- a/custom_components/button_plus/__init__.py
+++ b/custom_components/button_plus/__init__.py
@@ -5,6 +5,7 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntry
 
 from .button_plus_api.model import DeviceConfiguration
 from .buttonplushub import ButtonPlusHub
@@ -41,6 +42,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # This is called when an entry/configured device is to be removed. The class
     # needs to unload itself, and remove callbacks. See the classes for further
     # details
+    _LOGGER.debug(f"Removing async_unload_entry")
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/custom_components/button_plus/button_plus_api/model.py
+++ b/custom_components/button_plus/button_plus_api/model.py
@@ -36,7 +36,7 @@ class Info:
         self.ip_address = ip_address
         self.firmware = firmware
         self.large_display = large_display
-        self.connectors = connectors
+        self.connectors : List[Connector] = connectors
         self.sensors = sensors
 
     @staticmethod


### PR DESCRIPTION
Looks like fixing #31 and #36 .

Note: The brightness PR should be also be changed to reflect this approach.

The problem was that we defined a 'global' collection, and every time we tried to add those in, it would add 'all' in the global, not only the new ones.