### PR TITLE
Fixing #50 - topics not there/empty

### DIFF
--- a/custom_components/button_plus/button_plus_api/model.py
+++ b/custom_components/button_plus/button_plus_api/model.py
@@ -51,11 +51,29 @@ class Info:
             sensors=[Sensor.from_dict(sensor) for sensor in data['sensors']]
         )
 
+class Topic:
+    def __init__(self, broker_id: str, topic: str, payload: str, event_type: int):
+        self.broker_id = broker_id
+        self.topic = topic
+        self.payload = payload
+        self.event_type = event_type
+
+    def connector_type_enum(self) -> EventType:
+        return EventType(self.event_type)
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> 'Topic':
+        return Topic(
+            broker_id=data['brokerid'],
+            topic=data['topic'],
+            payload=data['payload'],
+            event_type=data['eventtype']
+        )
 
 class Core:
     def __init__(self, name: str, location: str, auto_backup: bool, brightness_large_display: int,
                  brightness_mini_display: int, led_color_front: int, led_color_wall: int, color: int,
-                 topics: List[Dict[str, Any]]):
+                 topics: List[Topic]):
         self.name = name
         self.location = location
         self.auto_backup = auto_backup
@@ -77,13 +95,13 @@ class Core:
             led_color_front=data['ledcolorfront'],
             led_color_wall=data['ledcolorwall'],
             color=data['color'],
-            topics=data['topics']
+            topics=[Topic.from_dict(topic) for topic in data.get('topics', [])]
         )
 
 
 class MqttButton:
     def __init__(self, button_id: int, label: str, top_label: str, led_color_front: int, led_color_wall: int,
-                 long_delay: int, long_repeat: int, topics: List[Dict[str, Any]]):
+                 long_delay: int, long_repeat: int, topics: List[Topic]):
         self.button_id = button_id
         self.label = label
         self.top_label = top_label
@@ -103,24 +121,7 @@ class MqttButton:
             led_color_wall=data['ledcolorwall'],
             long_delay=data['longdelay'],
             long_repeat=data['longrepeat'],
-            topics=data['topics']
-        )
-
-
-class Topic:
-    def __init__(self, broker_id: str, topic: str, payload: str, event_type: int):
-        self.broker_id = broker_id
-        self.topic = topic
-        self.payload = payload
-        self.event_type = event_type
-
-    @staticmethod
-    def from_dict(data: Dict[str, Any]) -> 'Topic':
-        return Topic(
-            broker_id=data['brokerid'],
-            topic=data['topic'],
-            payload=data['payload'],
-            event_type=data['eventtype']
+            topics=[Topic.from_dict(topic) for topic in data.get('topics', [])]
         )
 
 
@@ -148,7 +149,7 @@ class MqttDisplay:
             label=data['label'],
             unit=data['unit'],
             round=data['round'],
-            topics=[Topic.from_dict(topic) for topic in data['topics']]
+            topics=[Topic.from_dict(topic) for topic in data.get('topics', [])]
         )
 
 


### PR DESCRIPTION
Some extra safeguards. I think there is a edge case when there is no array there, that it throws because the json property `topics` is not there yet in the config.